### PR TITLE
remove unnecessary toggle method in App

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,9 +78,6 @@
       }
     },
     methods: {
-      toggle() {
-        this.$store.commit('toggle');
-      },
       updateTemplate() {
         this.$store.commit('updateTemplate');
       },


### PR DESCRIPTION
Had an optional toggle method in app that I never ended up using, code cleanup